### PR TITLE
Support event loop polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for using `dma::poll()` in an event loop.
+- Return values from `dma::poll()`, allowing users to block until the logger
+  is idle. See the documentation for usage tips.
+- Documentation describing usage patterns for the async logger.
+- Support DMA transfer rescheduling on loging calls. See the documentation for
+  when this might be appropriate.
+
+### Fixes
+
+- Note that `dma::poll()` will panic if there is no logger.
+
+### Changes
+
+- Requires `imxrt-hal` version 0.4, which introduces breaking changes.
+  See the [`imxrt-hal` release notes](https://github.com/imxrt-rs/imxrt-rs/releases)
+  for more information.
+- Measure logger performance in clock cycles, rather than elapsed time.
+
 ## [0.1.1] - 2020-07-07
 
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ cortex-m = "0.6.2"
 
 [dependencies.imxrt-hal]
 version = "0.3.0"
+path = "../imxrt/imxrt-hal"
 
 [features]
 # TODO add features for other variants once available in the HAL.
@@ -39,7 +40,11 @@ byob = []
 [target.thumbv7em-none-eabihf.dev-dependencies]
 teensy4-rt  = { git = "https://github.com/mciantyre/teensy4-rs.git" }
 teensy4-fcb = { git = "https://github.com/mciantyre/teensy4-rs.git" }
-imxrt-hal   = { version = "0.3.0", features = ["imxrt1062", "rt"] }
+
+[target.thumbv7em-none-eabihf.dev-dependencies.imxrt-hal]
+version = "0.3.0"
+features = ["imxrt1062", "rt"]
+path = "../imxrt/imxrt-hal"
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ cortex-m = "0.6.2"
 
 [dependencies.imxrt-hal]
 version = "0.3.0"
-path = "../imxrt/imxrt-hal"
+git = "https://github.com/imxrt-rs/imxrt-rs.git"
+rev = "1815db6"
 
 [features]
 # TODO add features for other variants once available in the HAL.
@@ -44,7 +45,8 @@ teensy4-fcb = { git = "https://github.com/mciantyre/teensy4-rs.git" }
 [target.thumbv7em-none-eabihf.dev-dependencies.imxrt-hal]
 version = "0.3.0"
 features = ["imxrt1062", "rt"]
-path = "../imxrt/imxrt-hal"
+git = "https://github.com/imxrt-rs/imxrt-rs.git"
+rev = "1815db6"
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -20,28 +20,11 @@ Built on the [`imxrt-hal`] hardware abstraction layer for i.MX RT processors, ve
 [`imxrt-hal`]: https://crates.io/crates/imxrt-hal
 [`log`]: https://crates.io/crates/log
 
-See the documentation for recommended use-cases, implementation descriptions, and examples:
-
-```
-cargo doc --open
-```
-
 ## i.MX RT Compatibility
 
 This crate supports all of the same i.MX RT variants as the [`imxrt-hal`] crate. To see the supported i.MX RT variants, check the [HAL's feature support](https://github.com/imxrt-rs/imxrt-rs#hal) list.
 
 > :information_source: As of this writing, the HAL only supports one i.MX RT variant, the `"imxrt1062"`. For convenience, the `"imxrt1062"` feature is this crate's **default** feature. This default feature may change in future releases.
-
-## Performance
-
-The table below describes the execution time for logging statements on a Teensy 4. For more information on the test setup, consult the crate documentation. See the two examples to reproduce the test.
-
-| Logging Invocation                                    | Execution Time, Blocking (us) | Execution Time, DMA (us) |
-| ----------------------------------------------------- | ----------------------------- | ------------------------ |
-| `log::info!("Hello world! 3 + 2 = {}", 3 + 2);`       | 3120                          | 3.16                     |
-| `log::info!("Hello world! 3 + 2 = 5");`               | 3120                          | 2.84                     |
-| `log::info!("");`                                     | 1220                          | 2.36                     |
-| `log::info!(/* 100 character string */);`             | 9880                          | 4.12                     |
 
 ## Testing
 

--- a/examples/demo/mod.rs
+++ b/examples/demo/mod.rs
@@ -1,0 +1,48 @@
+//! Demo code that's shared in each example
+
+use core::time::Duration;
+use imxrt_hal::gpt::{OutputCompareRegister, GPT};
+
+/// Output compare register that we'll use for delays
+const DELAY_OCR: OutputCompareRegister = OutputCompareRegister::Two;
+
+/// Blocking delay implemented on the GPT timer
+fn delay(gpt: &mut GPT) {
+    use embedded_hal::timer::CountDown;
+    let mut cd = gpt.count_down(DELAY_OCR);
+    cd.start(Duration::from_millis(1_000));
+    while cd.wait().is_err() {
+        core::sync::atomic::spin_loop_hint();
+    }
+}
+
+/// Drop into an infinite loop that prints example messages over
+/// serial.
+pub fn log_loop(mut gpt: GPT) -> ! {
+    loop {
+        let (_, duration) = gpt.time(|| {
+            log::info!("Hello world! 3 + 2 = {}", 3 + 2);
+        });
+        log::info!("Logging that took {:?}", duration);
+        delay(&mut gpt);
+
+        let (_, duration) = gpt.time(|| {
+            log::info!("Hello world! 3 + 2 = 5");
+        });
+        log::info!("Logging that took {:?}", duration);
+        delay(&mut gpt);
+
+        let (_, duration) = gpt.time(|| {
+            log::info!("");
+        });
+        log::info!("Logging that took {:?}", duration);
+        delay(&mut gpt);
+
+        let (_, duration) = gpt.time(|| {
+            // 100 characters
+            log::info!("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
+        });
+        log::info!("Logging that took {:?}", duration);
+        delay(&mut gpt);
+    }
+}

--- a/examples/demo/mod.rs
+++ b/examples/demo/mod.rs
@@ -22,21 +22,18 @@ fn log_loop_impl<F: Fn()>(mut gpt: GPT, func: F) -> ! {
             log::info!("Hello world! 3 + 2 = {}", 3 + 2);
         });
         log::info!("Logging that took {:?}", duration);
-        func();
         delay(&mut gpt);
 
         let (_, duration) = gpt.time(|| {
             log::info!("Hello world! 3 + 2 = 5");
         });
         log::info!("Logging that took {:?}", duration);
-        func();
         delay(&mut gpt);
 
         let (_, duration) = gpt.time(|| {
             log::info!("");
         });
         log::info!("Logging that took {:?}", duration);
-        func();
         delay(&mut gpt);
 
         let (_, duration) = gpt.time(|| {
@@ -44,8 +41,9 @@ fn log_loop_impl<F: Fn()>(mut gpt: GPT, func: F) -> ! {
             log::info!("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
         });
         log::info!("Logging that took {:?}", duration);
-        func();
         delay(&mut gpt);
+
+        func();
     }
 }
 

--- a/examples/demo/mod.rs
+++ b/examples/demo/mod.rs
@@ -16,26 +16,27 @@ fn delay(gpt: &mut GPT) {
     }
 }
 
-/// Drop into an infinite loop that prints example messages over
-/// serial.
-pub fn log_loop(mut gpt: GPT) -> ! {
+fn log_loop_impl<F: Fn()>(mut gpt: GPT, func: F) -> ! {
     loop {
         let (_, duration) = gpt.time(|| {
             log::info!("Hello world! 3 + 2 = {}", 3 + 2);
         });
         log::info!("Logging that took {:?}", duration);
+        func();
         delay(&mut gpt);
 
         let (_, duration) = gpt.time(|| {
             log::info!("Hello world! 3 + 2 = 5");
         });
         log::info!("Logging that took {:?}", duration);
+        func();
         delay(&mut gpt);
 
         let (_, duration) = gpt.time(|| {
             log::info!("");
         });
         log::info!("Logging that took {:?}", duration);
+        func();
         delay(&mut gpt);
 
         let (_, duration) = gpt.time(|| {
@@ -43,6 +44,21 @@ pub fn log_loop(mut gpt: GPT) -> ! {
             log::info!("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
         });
         log::info!("Logging that took {:?}", duration);
+        func();
         delay(&mut gpt);
     }
+}
+
+/// Drop into an infinite loop that prints messages over serial.
+#[allow(unused)]
+pub fn log_loop(gpt: GPT) -> ! {
+    log_loop_impl(gpt, || {})
+}
+
+/// Drop into an infinite loop that prints messages over serial.
+///
+/// Before each delay, we call `imxrt_uart_log::dma::poll()`.
+#[allow(unused)]
+pub fn log_loop_poll(gpt: GPT) -> ! {
+    log_loop_impl(gpt, imxrt_uart_log::dma::poll)
 }

--- a/examples/demo/mod.rs
+++ b/examples/demo/mod.rs
@@ -1,10 +1,29 @@
 //! Demo code that's shared in each example
 
 use core::time::Duration;
+use imxrt_hal::gpt;
 use imxrt_hal::gpt::{OutputCompareRegister, GPT};
+use imxrt_hal::ral::interrupt;
+use teensy4_rt::interrupt;
 
 /// Output compare register that we'll use for delays
 const DELAY_OCR: OutputCompareRegister = OutputCompareRegister::Two;
+
+static mut TIMER: Option<gpt::GPT> = None;
+
+/// GPT output compare register selection
+const INTERRUPT_OCR: gpt::OutputCompareRegister = gpt::OutputCompareRegister::Three;
+const INTERRUPT_PERIOD: Duration = Duration::from_millis(850);
+
+#[interrupt]
+unsafe fn GPT1() {
+    let gpt1 = TIMER.as_mut().unwrap();
+    gpt1.output_compare_status(INTERRUPT_OCR).clear();
+    gpt1.set_enable(false);
+    log::warn!("Called from interrupt!");
+    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
+    gpt1.set_enable(true);
+}
 
 /// Blocking delay implemented on the GPT timer
 pub fn delay(gpt: &mut GPT) {
@@ -16,36 +35,79 @@ pub fn delay(gpt: &mut GPT) {
     }
 }
 
+pub struct Setup {
+    pub ccm: imxrt_hal::ccm::CCM,
+    pub dcdc: imxrt_hal::dcdc::DCDC,
+    pub gpt1: imxrt_hal::gpt::Unclocked,
+    pub gpt2: imxrt_hal::gpt::Unclocked,
+}
+
 /// Drop into the common loop that logs data
 ///
 /// `func()` is an operation that will run at the beginning of each
 /// loop.
-pub fn log_loop<F: Fn(&mut GPT)>(mut gpt: GPT, func: F) -> ! {
+pub fn log_loop<F: Fn(&mut GPT)>(mut setup: Setup, func: F) -> ! {
+    let (_, ipg_hz) = setup.ccm.pll1.set_arm_clock(
+        imxrt_hal::ccm::PLL1::ARM_HZ,
+        &mut setup.ccm.handle,
+        &mut setup.dcdc,
+    );
+
+    //
+    // GPT2 initialization (for timing how long logging takes)
+    //
+    let mut cfg = setup.ccm.perclk.configure(
+        &mut setup.ccm.handle,
+        imxrt_hal::ccm::perclk::PODF::DIVIDE_3,
+        imxrt_hal::ccm::perclk::CLKSEL::IPG(ipg_hz),
+    );
+
+    let mut gpt2 = setup.gpt2.clock(&mut cfg);
+    gpt2.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
+    gpt2.set_enable(true);
+
+    //
+    // GPT1 initialization (for demonstrating logging in an interrupt)
+    //
+    let mut gpt1 = setup.gpt1.clock(&mut cfg);
+    gpt1.set_output_interrupt_on_compare(INTERRUPT_OCR, true);
+    gpt1.set_wait_mode_enable(true);
+    gpt1.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
+
+    gpt1.set_enable(false);
+    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
+    gpt1.set_enable(true);
+
+    unsafe {
+        TIMER = Some(gpt1);
+        cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
+    }
+
     loop {
-        func(&mut gpt);
-        let (_, duration) = gpt.time(|| {
+        func(&mut gpt2);
+        let (_, duration) = gpt2.time(|| {
             log::info!("Hello world! 3 + 2 = {}", 3 + 2);
         });
         log::info!("Logging that took {:?}", duration);
-        delay(&mut gpt);
+        delay(&mut gpt2);
 
-        let (_, duration) = gpt.time(|| {
+        let (_, duration) = gpt2.time(|| {
             log::info!("Hello world! 3 + 2 = 5");
         });
         log::info!("Logging that took {:?}", duration);
-        delay(&mut gpt);
+        delay(&mut gpt2);
 
-        let (_, duration) = gpt.time(|| {
+        let (_, duration) = gpt2.time(|| {
             log::info!("");
         });
         log::info!("Logging that took {:?}", duration);
-        delay(&mut gpt);
+        delay(&mut gpt2);
 
-        let (_, duration) = gpt.time(|| {
+        let (_, duration) = gpt2.time(|| {
             // 100 characters
             log::info!("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
         });
         log::info!("Logging that took {:?}", duration);
-        delay(&mut gpt);
+        delay(&mut gpt2);
     }
 }

--- a/examples/t4_blocking.rs
+++ b/examples/t4_blocking.rs
@@ -15,54 +15,36 @@ extern crate teensy4_fcb;
 
 mod demo;
 
-use core::time::Duration;
-use imxrt_hal::gpt;
-use imxrt_hal::ral::interrupt;
 use teensy4_rt::entry;
-use teensy4_rt::interrupt;
 
 const BAUD: u32 = 115_200;
 const TX_FIFO_SIZE: u8 = 4;
 
-static mut TIMER: Option<gpt::GPT> = None;
-
-/// GPT output compare register selection
-const INTERRUPT_OCR: gpt::OutputCompareRegister = gpt::OutputCompareRegister::Three;
-const INTERRUPT_PERIOD: Duration = Duration::from_millis(850);
-
-#[interrupt]
-unsafe fn GPT1() {
-    let gpt1 = TIMER.as_mut().unwrap();
-    gpt1.output_compare_status(INTERRUPT_OCR).clear();
-    gpt1.set_enable(false);
-    log::warn!("Called from interrupt!");
-    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
-    gpt1.set_enable(true);
-}
-
 #[entry]
 fn main() -> ! {
-    let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
-
-    let (_, ipg_hz) = peripherals.ccm.pll1.set_arm_clock(
-        imxrt_hal::ccm::PLL1::ARM_HZ,
-        &mut peripherals.ccm.handle,
-        &mut peripherals.dcdc,
-    );
+    let imxrt_hal::Peripherals {
+        uart,
+        mut ccm,
+        dcdc,
+        gpt1,
+        gpt2,
+        iomuxc,
+        ..
+    } = imxrt_hal::Peripherals::take().unwrap();
 
     //
     // UART initialization
     //
-    let uarts = peripherals.uart.clock(
-        &mut peripherals.ccm.handle,
+    let uarts = uart.clock(
+        &mut ccm.handle,
         imxrt_hal::ccm::uart::ClockSelect::OSC,
         imxrt_hal::ccm::uart::PrescalarSelect::DIVIDE_1,
     );
     let mut uart = uarts
         .uart2
         .init(
-            peripherals.iomuxc.gpio_ad_b1_02.alt2(),
-            peripherals.iomuxc.gpio_ad_b1_03.alt2(),
+            iomuxc.gpio_ad_b1_02.alt2(),
+            iomuxc.gpio_ad_b1_03.alt2(),
             BAUD,
         )
         .unwrap();
@@ -71,35 +53,13 @@ fn main() -> ! {
     let (tx, _) = uart.split();
     imxrt_uart_log::blocking::init(tx, Default::default()).unwrap();
 
-    //
-    // GPT2 initialization (for timing how long logging takes)
-    //
-    let mut cfg = peripherals.ccm.perclk.configure(
-        &mut peripherals.ccm.handle,
-        imxrt_hal::ccm::perclk::PODF::DIVIDE_3,
-        imxrt_hal::ccm::perclk::CLKSEL::IPG(ipg_hz),
+    demo::log_loop(
+        demo::Setup {
+            ccm,
+            dcdc,
+            gpt1,
+            gpt2,
+        },
+        |_| {},
     );
-
-    let mut gpt2 = peripherals.gpt2.clock(&mut cfg);
-    gpt2.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
-    gpt2.set_enable(true);
-
-    //
-    // GPT1 initialization (for demonstrating logging in an interrupt)
-    //
-    let mut gpt1 = peripherals.gpt1.clock(&mut cfg);
-    gpt1.set_output_interrupt_on_compare(INTERRUPT_OCR, true);
-    gpt1.set_wait_mode_enable(true);
-    gpt1.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
-
-    gpt1.set_enable(false);
-    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
-    gpt1.set_enable(true);
-
-    unsafe {
-        TIMER = Some(gpt1);
-        cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
-    }
-
-    demo::log_loop(gpt2, |_| {});
 }

--- a/examples/t4_blocking.rs
+++ b/examples/t4_blocking.rs
@@ -55,6 +55,7 @@ fn main() -> ! {
             dcdc,
             gpt1,
             gpt2,
+            dwt: cortex_m::Peripherals::take().unwrap().DWT,
         },
         |_| {},
     );

--- a/examples/t4_blocking.rs
+++ b/examples/t4_blocking.rs
@@ -101,5 +101,5 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
     }
 
-    demo::log_loop(gpt2);
+    demo::log_loop(gpt2, |_| {});
 }

--- a/examples/t4_blocking.rs
+++ b/examples/t4_blocking.rs
@@ -42,11 +42,7 @@ fn main() -> ! {
     );
     let mut uart = uarts
         .uart2
-        .init(
-            iomuxc.gpio_ad_b1_02.alt2(),
-            iomuxc.gpio_ad_b1_03.alt2(),
-            BAUD,
-        )
+        .init(iomuxc.ad_b1.p02, iomuxc.ad_b1.p03, BAUD)
         .unwrap();
     uart.set_tx_fifo(core::num::NonZeroU8::new(TX_FIFO_SIZE));
 

--- a/examples/t4_dma.rs
+++ b/examples/t4_dma.rs
@@ -3,10 +3,6 @@
 //! This use the same setup as the `t4_uart.rs` example. Connect
 //! a serial receive to pin 14, and you should receive log messages
 //! and timing measurements.
-//!
-//! Unlike the `t4_uart.rs` example, this example does not demonstrate
-//! logging from an interrupt. Logging from an interrupt is not supported
-//! with the DMA-based logger.
 
 #![no_std]
 #![no_main]
@@ -23,8 +19,24 @@ use teensy4_rt::interrupt;
 
 const BAUD: u32 = 115_200;
 
+/// GPT output compare register selection
+const INTERRUPT_OCR: gpt::OutputCompareRegister = gpt::OutputCompareRegister::Three;
+const INTERRUPT_PERIOD: Duration = Duration::from_millis(850);
+
 /// Output compare register that we'll use for delays
 const DELAY_OCR: gpt::OutputCompareRegister = gpt::OutputCompareRegister::Two;
+
+static mut TIMER: Option<gpt::GPT> = None;
+
+#[interrupt]
+unsafe fn GPT1() {
+    let gpt1 = TIMER.as_mut().unwrap();
+    gpt1.output_compare_status(INTERRUPT_OCR).clear();
+    gpt1.set_enable(false);
+    log::warn!("Called from interrupt!");
+    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
+    gpt1.set_enable(true);
+}
 
 #[interrupt]
 fn DMA7_DMA23() {
@@ -103,6 +115,23 @@ fn main() -> ! {
     let mut gpt2 = peripherals.gpt2.clock(&mut cfg);
     gpt2.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
     gpt2.set_enable(true);
+
+    //
+    // GPT1 initialization (for demonstrating logging in an interrupt)
+    //
+    let mut gpt1 = peripherals.gpt1.clock(&mut cfg);
+    gpt1.set_output_interrupt_on_compare(INTERRUPT_OCR, true);
+    gpt1.set_wait_mode_enable(true);
+    gpt1.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
+
+    gpt1.set_enable(false);
+    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
+    gpt1.set_enable(true);
+
+    unsafe {
+        TIMER = Some(gpt1);
+        cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
+    }
 
     let delay = |gpt: &mut gpt::GPT| {
         use embedded_hal::timer::CountDown;

--- a/examples/t4_dma.rs
+++ b/examples/t4_dma.rs
@@ -13,29 +13,11 @@ extern crate teensy4_fcb;
 
 mod demo;
 
-use core::time::Duration;
-use imxrt_hal::gpt;
 use imxrt_hal::ral::interrupt;
 use teensy4_rt::entry;
 use teensy4_rt::interrupt;
 
 const BAUD: u32 = 115_200;
-
-/// GPT output compare register selection
-const INTERRUPT_OCR: gpt::OutputCompareRegister = gpt::OutputCompareRegister::Three;
-const INTERRUPT_PERIOD: Duration = Duration::from_millis(850);
-
-static mut TIMER: Option<gpt::GPT> = None;
-
-#[interrupt]
-unsafe fn GPT1() {
-    let gpt1 = TIMER.as_mut().unwrap();
-    gpt1.output_compare_status(INTERRUPT_OCR).clear();
-    gpt1.set_enable(false);
-    log::warn!("Called from interrupt!");
-    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
-    gpt1.set_enable(true);
-}
 
 #[interrupt]
 fn DMA7_DMA23() {
@@ -56,18 +38,21 @@ mod buffer {
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
-
-    let (_, ipg_hz) = peripherals.ccm.pll1.set_arm_clock(
-        imxrt_hal::ccm::PLL1::ARM_HZ,
-        &mut peripherals.ccm.handle,
-        &mut peripherals.dcdc,
-    );
+    let imxrt_hal::Peripherals {
+        uart,
+        mut ccm,
+        dcdc,
+        gpt1,
+        gpt2,
+        iomuxc,
+        dma,
+        ..
+    } = imxrt_hal::Peripherals::take().unwrap();
 
     //
     // DMA initialization
     //
-    let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
+    let mut dma_channels = dma.clock(&mut ccm.handle);
     let mut channel = dma_channels[7].take().unwrap();
     channel.set_interrupt_on_completion(true);
     unsafe {
@@ -77,16 +62,16 @@ fn main() -> ! {
     //
     // UART initialization
     //
-    let uarts = peripherals.uart.clock(
-        &mut peripherals.ccm.handle,
+    let uarts = uart.clock(
+        &mut ccm.handle,
         imxrt_hal::ccm::uart::ClockSelect::OSC,
         imxrt_hal::ccm::uart::PrescalarSelect::DIVIDE_1,
     );
     let uart = uarts
         .uart2
         .init(
-            peripherals.iomuxc.gpio_ad_b1_02.alt2(),
-            peripherals.iomuxc.gpio_ad_b1_03.alt2(),
+            iomuxc.gpio_ad_b1_02.alt2(),
+            iomuxc.gpio_ad_b1_03.alt2(),
             BAUD,
         )
         .unwrap();
@@ -103,35 +88,13 @@ fn main() -> ! {
     )
     .unwrap();
 
-    //
-    // GPT2 initialization (for timing how long logging takes)
-    //
-    let mut cfg = peripherals.ccm.perclk.configure(
-        &mut peripherals.ccm.handle,
-        imxrt_hal::ccm::perclk::PODF::DIVIDE_3,
-        imxrt_hal::ccm::perclk::CLKSEL::IPG(ipg_hz),
+    demo::log_loop(
+        demo::Setup {
+            ccm,
+            dcdc,
+            gpt1,
+            gpt2,
+        },
+        |_| {},
     );
-
-    let mut gpt2 = peripherals.gpt2.clock(&mut cfg);
-    gpt2.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
-    gpt2.set_enable(true);
-
-    //
-    // GPT1 initialization (for demonstrating logging in an interrupt)
-    //
-    let mut gpt1 = peripherals.gpt1.clock(&mut cfg);
-    gpt1.set_output_interrupt_on_compare(INTERRUPT_OCR, true);
-    gpt1.set_wait_mode_enable(true);
-    gpt1.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
-
-    gpt1.set_enable(false);
-    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
-    gpt1.set_enable(true);
-
-    unsafe {
-        TIMER = Some(gpt1);
-        cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
-    }
-
-    demo::log_loop(gpt2, |_| {});
 }

--- a/examples/t4_dma.rs
+++ b/examples/t4_dma.rs
@@ -90,6 +90,7 @@ fn main() -> ! {
             dcdc,
             gpt1,
             gpt2,
+            dwt: cortex_m::Peripherals::take().unwrap().DWT,
         },
         |_| {},
     );

--- a/examples/t4_dma.rs
+++ b/examples/t4_dma.rs
@@ -69,11 +69,7 @@ fn main() -> ! {
     );
     let uart = uarts
         .uart2
-        .init(
-            iomuxc.gpio_ad_b1_02.alt2(),
-            iomuxc.gpio_ad_b1_03.alt2(),
-            BAUD,
-        )
+        .init(iomuxc.ad_b1.p02, iomuxc.ad_b1.p03, BAUD)
         .unwrap();
 
     let (tx, _) = uart.split();

--- a/examples/t4_dma.rs
+++ b/examples/t4_dma.rs
@@ -68,7 +68,8 @@ fn main() -> ! {
     // DMA initialization
     //
     let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
-    let channel = dma_channels[7].take().unwrap();
+    let mut channel = dma_channels[7].take().unwrap();
+    channel.set_interrupt_on_completion(true);
     unsafe {
         cortex_m::peripheral::NVIC::unmask(interrupt::DMA7_DMA23);
     }

--- a/examples/t4_dma.rs
+++ b/examples/t4_dma.rs
@@ -39,7 +39,7 @@ unsafe fn GPT1() {
 
 #[interrupt]
 fn DMA7_DMA23() {
-    imxrt_uart_log::dma::poll()
+    imxrt_uart_log::dma::poll();
 }
 
 /// See the "BYOB" documentation for more details
@@ -133,5 +133,5 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
     }
 
-    demo::log_loop(gpt2);
+    demo::log_loop(gpt2, |_| {});
 }

--- a/examples/t4_dma.rs
+++ b/examples/t4_dma.rs
@@ -11,6 +11,8 @@ extern crate panic_halt;
 #[cfg(target_arch = "arm")]
 extern crate teensy4_fcb;
 
+mod demo;
+
 use core::time::Duration;
 use imxrt_hal::gpt;
 use imxrt_hal::ral::interrupt;
@@ -22,9 +24,6 @@ const BAUD: u32 = 115_200;
 /// GPT output compare register selection
 const INTERRUPT_OCR: gpt::OutputCompareRegister = gpt::OutputCompareRegister::Three;
 const INTERRUPT_PERIOD: Duration = Duration::from_millis(850);
-
-/// Output compare register that we'll use for delays
-const DELAY_OCR: gpt::OutputCompareRegister = gpt::OutputCompareRegister::Two;
 
 static mut TIMER: Option<gpt::GPT> = None;
 
@@ -133,39 +132,5 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
     }
 
-    let delay = |gpt: &mut gpt::GPT| {
-        use embedded_hal::timer::CountDown;
-        let mut cd = gpt.count_down(DELAY_OCR);
-        cd.start(Duration::from_millis(1_000));
-        while cd.wait().is_err() {
-            core::sync::atomic::spin_loop_hint();
-        }
-    };
-
-    loop {
-        let (_, duration) = gpt2.time(|| {
-            log::info!("Hello world! 3 + 2 = {}", 3 + 2);
-        });
-        log::info!("Logging that took {:?}", duration);
-        delay(&mut gpt2);
-
-        let (_, duration) = gpt2.time(|| {
-            log::info!("Hello world! 3 + 2 = 5");
-        });
-        log::info!("Logging that took {:?}", duration);
-        delay(&mut gpt2);
-
-        let (_, duration) = gpt2.time(|| {
-            log::info!("");
-        });
-        log::info!("Logging that took {:?}", duration);
-        delay(&mut gpt2);
-
-        let (_, duration) = gpt2.time(|| {
-            // 100 characters
-            log::info!("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
-        });
-        log::info!("Logging that took {:?}", duration);
-        delay(&mut gpt2);
-    }
+    demo::log_loop(gpt2);
 }

--- a/examples/t4_idle.rs
+++ b/examples/t4_idle.rs
@@ -79,17 +79,17 @@ fn main() -> ! {
             dcdc,
             gpt1,
             gpt2,
+            dwt: cortex_m::Peripherals::take().unwrap().DWT,
         },
         |mut gpt| {
             imxrt_uart_log::dma::poll();
-            let duration = cortex_m::interrupt::free(|_| {
-                let (_, duration) = gpt.time(|| {
+            let cycle_count = cortex_m::interrupt::free(|_| {
+                demo::cycles(|| {
                     log::error!("I want to guarantee that this is transferred!");
                     while imxrt_uart_log::dma::Poll::Idle != imxrt_uart_log::dma::poll() {}
-                });
-                duration
+                })
             });
-            log::error!("Flushing the async logger took {:?}", duration);
+            log::error!("Flushing the async logger took {} cycles", cycle_count);
             demo::delay(&mut gpt);
         },
     );

--- a/examples/t4_idle.rs
+++ b/examples/t4_idle.rs
@@ -1,0 +1,128 @@
+//! DMA-based serial logging - Teensy 4 example
+//!
+//! Unlike the t4_dma example, this example shows that you can manually
+//! add `poll()` points into your code, rather than putting `poll()` in
+//! DMA interrupt, to drive serial logging.
+
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+#[cfg(target_arch = "arm")]
+extern crate teensy4_fcb;
+
+mod demo;
+
+use core::time::Duration;
+use imxrt_hal::gpt;
+use imxrt_hal::ral::interrupt;
+use teensy4_rt::entry;
+use teensy4_rt::interrupt;
+
+const BAUD: u32 = 115_200;
+
+/// GPT output compare register selection
+const INTERRUPT_OCR: gpt::OutputCompareRegister = gpt::OutputCompareRegister::Three;
+const INTERRUPT_PERIOD: Duration = Duration::from_millis(850);
+
+static mut TIMER: Option<gpt::GPT> = None;
+
+#[interrupt]
+unsafe fn GPT1() {
+    let gpt1 = TIMER.as_mut().unwrap();
+    gpt1.output_compare_status(INTERRUPT_OCR).clear();
+    gpt1.set_enable(false);
+    log::warn!("Called from interrupt!");
+    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
+    gpt1.set_enable(true);
+}
+
+/// See the "BYOB" documentation for more details
+#[cfg(feature = "byob")]
+mod buffer {
+    use imxrt_hal::dma::Buffer;
+    pub use imxrt_hal::dma::Circular;
+
+    // Using a 512-byte buffer, rather than the 2KiB default buffer
+    #[repr(align(512))]
+    pub struct Alignment(pub Buffer<[u8; 512]>);
+    pub static BUFFER: Alignment = Alignment(Buffer::new([0; 512]));
+}
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
+
+    let (_, ipg_hz) = peripherals.ccm.pll1.set_arm_clock(
+        imxrt_hal::ccm::PLL1::ARM_HZ,
+        &mut peripherals.ccm.handle,
+        &mut peripherals.dcdc,
+    );
+
+    //
+    // DMA initialization
+    //
+    let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
+    let channel = dma_channels[7].take().unwrap();
+
+    //
+    // UART initialization
+    //
+    let uarts = peripherals.uart.clock(
+        &mut peripherals.ccm.handle,
+        imxrt_hal::ccm::uart::ClockSelect::OSC,
+        imxrt_hal::ccm::uart::PrescalarSelect::DIVIDE_1,
+    );
+    let uart = uarts
+        .uart2
+        .init(
+            peripherals.iomuxc.gpio_ad_b1_02.alt2(),
+            peripherals.iomuxc.gpio_ad_b1_03.alt2(),
+            BAUD,
+        )
+        .unwrap();
+
+    let (tx, _) = uart.split();
+    imxrt_uart_log::dma::init(
+        tx,
+        channel,
+        Default::default(),
+        #[cfg(feature = "byob")]
+        {
+            buffer::Circular::new(&buffer::BUFFER.0).unwrap()
+        },
+    )
+    .unwrap();
+
+    //
+    // GPT2 initialization (for timing how long logging takes)
+    //
+    let mut cfg = peripherals.ccm.perclk.configure(
+        &mut peripherals.ccm.handle,
+        imxrt_hal::ccm::perclk::PODF::DIVIDE_3,
+        imxrt_hal::ccm::perclk::CLKSEL::IPG(ipg_hz),
+    );
+
+    let mut gpt2 = peripherals.gpt2.clock(&mut cfg);
+    gpt2.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
+    gpt2.set_enable(true);
+
+    //
+    // GPT1 initialization (for demonstrating logging in an interrupt)
+    //
+    let mut gpt1 = peripherals.gpt1.clock(&mut cfg);
+    gpt1.set_output_interrupt_on_compare(INTERRUPT_OCR, true);
+    gpt1.set_wait_mode_enable(true);
+    gpt1.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
+
+    gpt1.set_enable(false);
+    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
+    gpt1.set_enable(true);
+
+    unsafe {
+        TIMER = Some(gpt1);
+        cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
+    }
+
+    demo::log_loop_poll(gpt2);
+}

--- a/examples/t4_idle.rs
+++ b/examples/t4_idle.rs
@@ -13,29 +13,9 @@ extern crate teensy4_fcb;
 
 mod demo;
 
-use core::time::Duration;
-use imxrt_hal::gpt;
-use imxrt_hal::ral::interrupt;
 use teensy4_rt::entry;
-use teensy4_rt::interrupt;
 
 const BAUD: u32 = 115_200;
-
-/// GPT output compare register selection
-const INTERRUPT_OCR: gpt::OutputCompareRegister = gpt::OutputCompareRegister::Three;
-const INTERRUPT_PERIOD: Duration = Duration::from_millis(850);
-
-static mut TIMER: Option<gpt::GPT> = None;
-
-#[interrupt]
-unsafe fn GPT1() {
-    let gpt1 = TIMER.as_mut().unwrap();
-    gpt1.output_compare_status(INTERRUPT_OCR).clear();
-    gpt1.set_enable(false);
-    log::warn!("Called from interrupt!");
-    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
-    gpt1.set_enable(true);
-}
 
 /// See the "BYOB" documentation for more details
 #[cfg(feature = "byob")]
@@ -51,33 +31,36 @@ mod buffer {
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
-
-    let (_, ipg_hz) = peripherals.ccm.pll1.set_arm_clock(
-        imxrt_hal::ccm::PLL1::ARM_HZ,
-        &mut peripherals.ccm.handle,
-        &mut peripherals.dcdc,
-    );
+    let imxrt_hal::Peripherals {
+        uart,
+        mut ccm,
+        dcdc,
+        gpt1,
+        gpt2,
+        iomuxc,
+        dma,
+        ..
+    } = imxrt_hal::Peripherals::take().unwrap();
 
     //
     // DMA initialization
     //
-    let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
+    let mut dma_channels = dma.clock(&mut ccm.handle);
     let channel = dma_channels[7].take().unwrap();
 
     //
     // UART initialization
     //
-    let uarts = peripherals.uart.clock(
-        &mut peripherals.ccm.handle,
+    let uarts = uart.clock(
+        &mut ccm.handle,
         imxrt_hal::ccm::uart::ClockSelect::OSC,
         imxrt_hal::ccm::uart::PrescalarSelect::DIVIDE_1,
     );
     let uart = uarts
         .uart2
         .init(
-            peripherals.iomuxc.gpio_ad_b1_02.alt2(),
-            peripherals.iomuxc.gpio_ad_b1_03.alt2(),
+            iomuxc.gpio_ad_b1_02.alt2(),
+            iomuxc.gpio_ad_b1_03.alt2(),
             BAUD,
         )
         .unwrap();
@@ -94,46 +77,24 @@ fn main() -> ! {
     )
     .unwrap();
 
-    //
-    // GPT2 initialization (for timing how long logging takes)
-    //
-    let mut cfg = peripherals.ccm.perclk.configure(
-        &mut peripherals.ccm.handle,
-        imxrt_hal::ccm::perclk::PODF::DIVIDE_3,
-        imxrt_hal::ccm::perclk::CLKSEL::IPG(ipg_hz),
-    );
-
-    let mut gpt2 = peripherals.gpt2.clock(&mut cfg);
-    gpt2.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
-    gpt2.set_enable(true);
-
-    //
-    // GPT1 initialization (for demonstrating logging in an interrupt)
-    //
-    let mut gpt1 = peripherals.gpt1.clock(&mut cfg);
-    gpt1.set_output_interrupt_on_compare(INTERRUPT_OCR, true);
-    gpt1.set_wait_mode_enable(true);
-    gpt1.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
-
-    gpt1.set_enable(false);
-    gpt1.set_output_compare_duration(INTERRUPT_OCR, INTERRUPT_PERIOD);
-    gpt1.set_enable(true);
-
-    unsafe {
-        TIMER = Some(gpt1);
-        cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
-    }
-
-    demo::log_loop(gpt2, |mut gpt| {
-        imxrt_uart_log::dma::poll();
-        let duration = cortex_m::interrupt::free(|_| {
-            let (_, duration) = gpt.time(|| {
-                log::error!("I want to guarantee that this is transferred!");
-                while imxrt_uart_log::dma::Poll::Idle != imxrt_uart_log::dma::poll() {}
+    demo::log_loop(
+        demo::Setup {
+            ccm,
+            dcdc,
+            gpt1,
+            gpt2,
+        },
+        |mut gpt| {
+            imxrt_uart_log::dma::poll();
+            let duration = cortex_m::interrupt::free(|_| {
+                let (_, duration) = gpt.time(|| {
+                    log::error!("I want to guarantee that this is transferred!");
+                    while imxrt_uart_log::dma::Poll::Idle != imxrt_uart_log::dma::poll() {}
+                });
+                duration
             });
-            duration
-        });
-        log::error!("Flushing the async logger took {:?}", duration);
-        demo::delay(&mut gpt);
-    });
+            log::error!("Flushing the async logger took {:?}", duration);
+            demo::delay(&mut gpt);
+        },
+    );
 }

--- a/examples/t4_idle.rs
+++ b/examples/t4_idle.rs
@@ -58,11 +58,7 @@ fn main() -> ! {
     );
     let uart = uarts
         .uart2
-        .init(
-            iomuxc.gpio_ad_b1_02.alt2(),
-            iomuxc.gpio_ad_b1_03.alt2(),
-            BAUD,
-        )
+        .init(iomuxc.ad_b1.p02, iomuxc.ad_b1.p03, BAUD)
         .unwrap();
 
     let (tx, _) = uart.split();

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -42,8 +42,8 @@
 //! let mut uart = uarts
 //!     .uart2
 //!     .init(
-//!         peripherals.iomuxc.gpio_ad_b1_02.alt2(),
-//!         peripherals.iomuxc.gpio_ad_b1_03.alt2(),
+//!         peripherals.iomuxc.ad_b1.p02,
+//!         peripherals.iomuxc.ad_b1.p03,
 //!         115_200,
 //!     )
 //!     .unwrap();

--- a/src/blocking/sink.rs
+++ b/src/blocking/sink.rs
@@ -1,6 +1,7 @@
 //! Logging sink
 
 use core::fmt;
+use imxrt_hal::iomuxc;
 use imxrt_hal::uart;
 
 use embedded_hal::blocking::serial::Write;
@@ -8,7 +9,7 @@ use embedded_hal::blocking::serial::Write;
 // The implementation has a few `expects()` that assume no errors
 // from the UART write operations. This statically asserts that the
 // assumptions hold (at least for UART1...).
-type _Error = <uart::UART<uart::module::_1> as Write<u8>>::Error;
+type _Error = <uart::UART<iomuxc::consts::U1> as Write<u8>>::Error;
 trait _IsInfallible {
     const VALUE: bool = false;
 }
@@ -19,14 +20,14 @@ const _UART_ERROR_INFALLIBLE: [u8; 1] = [0; <_Error as _IsInfallible>::VALUE as 
 
 /// A logging sink which dispatches to any of the eight possible UART peripherals
 pub enum Sink {
-    _1(uart::Tx<uart::module::_1>),
-    _2(uart::Tx<uart::module::_2>),
-    _3(uart::Tx<uart::module::_3>),
-    _4(uart::Tx<uart::module::_4>),
-    _5(uart::Tx<uart::module::_5>),
-    _6(uart::Tx<uart::module::_6>),
-    _7(uart::Tx<uart::module::_7>),
-    _8(uart::Tx<uart::module::_8>),
+    _1(uart::Tx<iomuxc::consts::U1>),
+    _2(uart::Tx<iomuxc::consts::U2>),
+    _3(uart::Tx<iomuxc::consts::U3>),
+    _4(uart::Tx<iomuxc::consts::U4>),
+    _5(uart::Tx<iomuxc::consts::U5>),
+    _6(uart::Tx<iomuxc::consts::U6>),
+    _7(uart::Tx<iomuxc::consts::U7>),
+    _8(uart::Tx<iomuxc::consts::U8>),
 }
 
 impl fmt::Write for Sink {
@@ -60,50 +61,50 @@ impl Sink {
     }
 }
 
-impl From<uart::Tx<uart::module::_1>> for Sink {
-    fn from(tx: uart::Tx<uart::module::_1>) -> Self {
+impl From<uart::Tx<iomuxc::consts::U1>> for Sink {
+    fn from(tx: uart::Tx<iomuxc::consts::U1>) -> Self {
         Sink::_1(tx)
     }
 }
 
-impl From<uart::Tx<uart::module::_2>> for Sink {
-    fn from(tx: uart::Tx<uart::module::_2>) -> Self {
+impl From<uart::Tx<iomuxc::consts::U2>> for Sink {
+    fn from(tx: uart::Tx<iomuxc::consts::U2>) -> Self {
         Sink::_2(tx)
     }
 }
 
-impl From<uart::Tx<uart::module::_3>> for Sink {
-    fn from(tx: uart::Tx<uart::module::_3>) -> Self {
+impl From<uart::Tx<iomuxc::consts::U3>> for Sink {
+    fn from(tx: uart::Tx<iomuxc::consts::U3>) -> Self {
         Sink::_3(tx)
     }
 }
 
-impl From<uart::Tx<uart::module::_4>> for Sink {
-    fn from(tx: uart::Tx<uart::module::_4>) -> Self {
+impl From<uart::Tx<iomuxc::consts::U4>> for Sink {
+    fn from(tx: uart::Tx<iomuxc::consts::U4>) -> Self {
         Sink::_4(tx)
     }
 }
 
-impl From<uart::Tx<uart::module::_5>> for Sink {
-    fn from(tx: uart::Tx<uart::module::_5>) -> Self {
+impl From<uart::Tx<iomuxc::consts::U5>> for Sink {
+    fn from(tx: uart::Tx<iomuxc::consts::U5>) -> Self {
         Sink::_5(tx)
     }
 }
 
-impl From<uart::Tx<uart::module::_6>> for Sink {
-    fn from(tx: uart::Tx<uart::module::_6>) -> Self {
+impl From<uart::Tx<iomuxc::consts::U6>> for Sink {
+    fn from(tx: uart::Tx<iomuxc::consts::U6>) -> Self {
         Sink::_6(tx)
     }
 }
 
-impl From<uart::Tx<uart::module::_7>> for Sink {
-    fn from(tx: uart::Tx<uart::module::_7>) -> Self {
+impl From<uart::Tx<iomuxc::consts::U7>> for Sink {
+    fn from(tx: uart::Tx<iomuxc::consts::U7>) -> Self {
         Sink::_7(tx)
     }
 }
 
-impl From<uart::Tx<uart::module::_8>> for Sink {
-    fn from(tx: uart::Tx<uart::module::_8>) -> Self {
+impl From<uart::Tx<iomuxc::consts::U8>> for Sink {
+    fn from(tx: uart::Tx<iomuxc::consts::U8>) -> Self {
         Sink::_8(tx)
     }
 }

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -198,6 +198,9 @@ pub fn poll() {
 
         if logger.sink.is_transfer_interrupt() {
             logger.sink.transfer_clear_interrupt();
+        }
+
+        if logger.sink.is_transfer_complete() {
             let buffer = logger.sink.transfer_complete().unwrap();
             if !buffer.is_empty() {
                 // There's pending data to send

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -72,7 +72,8 @@
 //! );
 //!
 //! let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
-//! let channel = dma_channels[7].take().unwrap();
+//! let mut channel = dma_channels[7].take().unwrap();
+//! channel.set_interrupt_on_completion(true);
 //!
 //! let uarts = peripherals.uart.clock(
 //!     &mut peripherals.ccm.handle,

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -161,6 +161,20 @@ impl ::log::Log for Logger {
                     .expect("never fails");
                     // Start the transfer
                     logger.sink.start_transfer(buffer);
+                } else if logger.sink.is_transfer_complete() {
+                    // Transfer is complete. We need to complete the transfer,
+                    // and re-schedule it here.
+                    let mut buffer = logger.sink.transfer_complete().unwrap();
+                    write!(
+                        Writer::Circular(&mut buffer),
+                        "[{} {}]: {}\r\n",
+                        record.level(),
+                        record.target(),
+                        record.args()
+                    )
+                    .expect("never fails");
+                    // Start the transfer
+                    logger.sink.start_transfer(buffer);
                 } else {
                     // There's an active transfer; find the buffer in the peripheral,
                     // and fill it with data

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -5,17 +5,13 @@
 //! 1. Configure a UART peripheral with baud rates, parities, inversions, etc.
 //! 2. Select a DMA channel. Take note of the DMA channel number.
 //! 3. Implement the DMA channel's interrupt handler, and call [`poll()`](fn.poll.html)
-//!    in the implementation.
+//!    in the implementation. Or, call `poll()` throughout your event loop.
 //! 4. Unmask the interrupt via an `unsafe` call to `cortex_m::interrupt::unmask()`.
 //! 5. Call [`init`](fn.init.html) with all of
 //!   - a UART transfer half,
 //!   - a DMA channel
 //!   - a logging configuration
 //! 6. Use the macros from the [`log`](https://crates.io/crates/log) crate to write data
-//!
-//! You cannot use [`poll()`](fn.poll.html) in an event loop. The implementation assumes that you have
-//! overridden your DMA channel's interrupt handler. If `poll()` is not called in your DMA channel's
-//! interrupt handler, the logger will not work.
 //!
 //! Optionally, you may specify your own DMA buffer. See the [BYOB](#byob) feature to learn about
 //! user-supplied DMA buffers.
@@ -38,10 +34,6 @@
 //! By default, the implementation relies on a 2KiB statically-allocated circular buffer. If you saturate
 //! the buffer before the next transfer is scheduled, the data that cannot be copied into the buffer
 //! **will be dropped.** Either keep messages small, or keep messages infrequent, to avoid circular buffer saturation.
-//!
-//! The implementation assumes that you have provided the DMA channel's interrupt handler. The DMA channel's interrupt
-//! handler will be called when each DMA transfer completes, even if you have not registered your DMA channel's interrupt
-//! handler.
 //!
 //! # Tips
 //!
@@ -195,9 +187,8 @@ impl ::log::Log for Logger {
 
 /// Drives DMA-based logging over serial
 ///
-/// You *must* call this repeatedly to drive the DMA-based logging. You must
-/// enable the interrupt for a DMA channel, and call `poll()` in the interrupt
-/// handler.
+/// You *must* call this repeatedly to drive the DMA-based logging. Calling `poll()`
+/// can happen in the DMA channel's interrupt handler, or throughout an event loop.
 ///
 /// If the transfer is not complete, `poll()` does nothing.
 #[inline]

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -123,8 +123,8 @@
 //! let uart = uarts
 //!     .uart2
 //!     .init(
-//!         peripherals.iomuxc.gpio_ad_b1_02.alt2(),
-//!         peripherals.iomuxc.gpio_ad_b1_03.alt2(),
+//!         peripherals.iomuxc.ad_b1.p02,
+//!         peripherals.iomuxc.ad_b1.p03,
 //!         115_200,
 //!     )
 //!     .unwrap();

--- a/src/dma/sink.rs
+++ b/src/dma/sink.rs
@@ -1,7 +1,7 @@
 //! DMA sink
 
 use imxrt_hal::{
-    dma::{Channel, Circular, Config, ConfigBuilder, Peripheral, WriteHalf},
+    dma::{Channel, Circular, Peripheral, WriteHalf},
     uart::{module, Tx},
 };
 
@@ -106,54 +106,50 @@ pub trait IntoSink {
     fn into_sink(self, channel: Channel) -> Sink;
 }
 
-fn config() -> Config {
-    ConfigBuilder::new().interrupt_on_completion(true).build()
-}
-
 impl IntoSink for Tx<module::_1> {
     fn into_sink(self, channel: Channel) -> Sink {
-        Sink::_1(Peripheral::new_transfer(self, channel, config()))
+        Sink::_1(Peripheral::new_transfer(self, channel))
     }
 }
 
 impl IntoSink for Tx<module::_2> {
     fn into_sink(self, channel: Channel) -> Sink {
-        Sink::_2(Peripheral::new_transfer(self, channel, config()))
+        Sink::_2(Peripheral::new_transfer(self, channel))
     }
 }
 
 impl IntoSink for Tx<module::_3> {
     fn into_sink(self, channel: Channel) -> Sink {
-        Sink::_3(Peripheral::new_transfer(self, channel, config()))
+        Sink::_3(Peripheral::new_transfer(self, channel))
     }
 }
 
 impl IntoSink for Tx<module::_4> {
     fn into_sink(self, channel: Channel) -> Sink {
-        Sink::_4(Peripheral::new_transfer(self, channel, config()))
+        Sink::_4(Peripheral::new_transfer(self, channel))
     }
 }
 
 impl IntoSink for Tx<module::_5> {
     fn into_sink(self, channel: Channel) -> Sink {
-        Sink::_5(Peripheral::new_transfer(self, channel, config()))
+        Sink::_5(Peripheral::new_transfer(self, channel))
     }
 }
 
 impl IntoSink for Tx<module::_6> {
     fn into_sink(self, channel: Channel) -> Sink {
-        Sink::_6(Peripheral::new_transfer(self, channel, config()))
+        Sink::_6(Peripheral::new_transfer(self, channel))
     }
 }
 
 impl IntoSink for Tx<module::_7> {
     fn into_sink(self, channel: Channel) -> Sink {
-        Sink::_7(Peripheral::new_transfer(self, channel, config()))
+        Sink::_7(Peripheral::new_transfer(self, channel))
     }
 }
 
 impl IntoSink for Tx<module::_8> {
     fn into_sink(self, channel: Channel) -> Sink {
-        Sink::_8(Peripheral::new_transfer(self, channel, config()))
+        Sink::_8(Peripheral::new_transfer(self, channel))
     }
 }

--- a/src/dma/sink.rs
+++ b/src/dma/sink.rs
@@ -2,21 +2,22 @@
 
 use imxrt_hal::{
     dma::{Channel, Circular, Peripheral, WriteHalf},
-    uart::{module, Tx},
+    iomuxc,
+    uart::Tx,
 };
 
 /// DMA output
 type Output<M> = Peripheral<Tx<M>, u8, Circular<u8>>;
 
 pub enum Sink {
-    _1(Output<module::_1>),
-    _2(Output<module::_2>),
-    _3(Output<module::_3>),
-    _4(Output<module::_4>),
-    _5(Output<module::_5>),
-    _6(Output<module::_6>),
-    _7(Output<module::_7>),
-    _8(Output<module::_8>),
+    _1(Output<iomuxc::consts::U1>),
+    _2(Output<iomuxc::consts::U2>),
+    _3(Output<iomuxc::consts::U3>),
+    _4(Output<iomuxc::consts::U4>),
+    _5(Output<iomuxc::consts::U5>),
+    _6(Output<iomuxc::consts::U6>),
+    _7(Output<iomuxc::consts::U7>),
+    _8(Output<iomuxc::consts::U8>),
 }
 
 impl Sink {
@@ -119,49 +120,49 @@ pub trait IntoSink {
     fn into_sink(self, channel: Channel) -> Sink;
 }
 
-impl IntoSink for Tx<module::_1> {
+impl IntoSink for Tx<iomuxc::consts::U1> {
     fn into_sink(self, channel: Channel) -> Sink {
         Sink::_1(Peripheral::new_transfer(self, channel))
     }
 }
 
-impl IntoSink for Tx<module::_2> {
+impl IntoSink for Tx<iomuxc::consts::U2> {
     fn into_sink(self, channel: Channel) -> Sink {
         Sink::_2(Peripheral::new_transfer(self, channel))
     }
 }
 
-impl IntoSink for Tx<module::_3> {
+impl IntoSink for Tx<iomuxc::consts::U3> {
     fn into_sink(self, channel: Channel) -> Sink {
         Sink::_3(Peripheral::new_transfer(self, channel))
     }
 }
 
-impl IntoSink for Tx<module::_4> {
+impl IntoSink for Tx<iomuxc::consts::U4> {
     fn into_sink(self, channel: Channel) -> Sink {
         Sink::_4(Peripheral::new_transfer(self, channel))
     }
 }
 
-impl IntoSink for Tx<module::_5> {
+impl IntoSink for Tx<iomuxc::consts::U5> {
     fn into_sink(self, channel: Channel) -> Sink {
         Sink::_5(Peripheral::new_transfer(self, channel))
     }
 }
 
-impl IntoSink for Tx<module::_6> {
+impl IntoSink for Tx<iomuxc::consts::U6> {
     fn into_sink(self, channel: Channel) -> Sink {
         Sink::_6(Peripheral::new_transfer(self, channel))
     }
 }
 
-impl IntoSink for Tx<module::_7> {
+impl IntoSink for Tx<iomuxc::consts::U7> {
     fn into_sink(self, channel: Channel) -> Sink {
         Sink::_7(Peripheral::new_transfer(self, channel))
     }
 }
 
-impl IntoSink for Tx<module::_8> {
+impl IntoSink for Tx<iomuxc::consts::U8> {
     fn into_sink(self, channel: Channel) -> Sink {
         Sink::_8(Peripheral::new_transfer(self, channel))
     }

--- a/src/dma/sink.rs
+++ b/src/dma/sink.rs
@@ -46,6 +46,19 @@ impl Sink {
         }
     }
 
+    pub fn is_transfer_complete(&self) -> bool {
+        match self {
+            Sink::_1(periph) => periph.is_transfer_complete(),
+            Sink::_2(periph) => periph.is_transfer_complete(),
+            Sink::_3(periph) => periph.is_transfer_complete(),
+            Sink::_4(periph) => periph.is_transfer_complete(),
+            Sink::_5(periph) => periph.is_transfer_complete(),
+            Sink::_6(periph) => periph.is_transfer_complete(),
+            Sink::_7(periph) => periph.is_transfer_complete(),
+            Sink::_8(periph) => periph.is_transfer_complete(),
+        }
+    }
+
     pub fn transfer_complete(&mut self) -> Option<Circular<u8>> {
         match self {
             Sink::_1(periph) => periph.transfer_complete(),

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -2,7 +2,7 @@
 
 /// Filter log messages by module name (`&'static str`) to a log level
 ///
-/// - if the level is `None`, log at all levels from the module
+/// - if the level is `None`, log at all levels from the module (subject to the max log level)
 /// - if the level is not `None`, that will be the base log level for the module
 ///
 /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,8 @@
 //!
 //! # Performance
 //!
-//! We measured logging execution on a Teensy 4, with a 600MHz ARM clock. We configured
-//! a UART peripheral following the examples in each module. Using a general purpose timer (GPT),
-//! we measured the time required to write various log messages. We verified GPT timings
-//! with a logic analyzer, which observed a pulse on a GPIO.
+//! We measured logging execution on a Teensy 4. We configured a UART peripheral following the examples in each module.
+//! We measured the CPU clock cycles required to execute each logging statement.
 //!
 //! By default, a logging call resembling
 //!
@@ -43,15 +41,14 @@
 //! where `INFO` describes the log level, `log_uart` describes the module, and the remainder
 //! of the message is the serialized content.
 //!
-//! The table notes execution time in microseconds (us). Execution time is the time elapsed between the start and end
-//! of a `log::info!()` execution.
+//! CPU clock cycles measure the elapse of cycle counts before and after a `log::info!()` macro.
 //!
-//! | Logging Invocation                                    | Execution Time, Blocking (us) | Execution Time, DMA (us) |
-//! | ----------------------------------------------------- | ----------------------------- | ------------------------ |
-//! | `log::info!("Hello world! 3 + 2 = {}", 3 + 2);`       | 3120                          | 3.16                     |
-//! | `log::info!("Hello world! 3 + 2 = 5");`               | 3120                          | 2.84                     |
-//! | `log::info!("");`                                     | 1220                          | 2.36                     |
-//! | `log::info!(/* 100 character string */);`             | 9880                          | 4.12                     |
+//! | Logging Invocation                                    | CPU Clock Cycles, Blocking | CPU Clock Cycles, DMA |
+//! | ----------------------------------------------------- | -------------------------- | --------------------- |
+//! | `log::info!("Hello world! 3 + 2 = {}", 3 + 2);`       | 2341330                    | 1871                  |
+//! | `log::info!("Hello world! 3 + 2 = 5");`               | 2341273                    | 1683                  |
+//! | `log::info!("");`                                     | 1197246                    | 1428                  |
+//! | `log::info!(/* 100 character string */);`             | 6397302                    | 2463                  |
 //!
 //! Use this crate's examples to reproduce these measurements.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@ use filters::Filters;
 /// const MOTOR_LOGGING: Filter = ("motor", Some(log::LevelFilter::Trace));
 ///
 /// let config = LoggingConfig {
-///     // To use the statically-specified max log level, use log::STATIC_MAX_LEVEL
 ///     max_level: log::LevelFilter::Debug,
 ///     filters: &[
 ///         I2C_LOGGING,
@@ -118,7 +117,7 @@ impl Default for LoggingConfig {
 
 /// An error that indicates the logger is already set
 ///
-/// The error could propagate from this crate's [`init()`](fn.init.html) function.
+/// The error could propagate from one of the `init()` functions.
 /// Or, it could propagate if the underlying logger was set through another logging
 /// interface.
 #[derive(Debug)]


### PR DESCRIPTION
The PR adds proper support for driving the async logger in an event loop. After this PR, users are not required to implement the DMA channel's interrupt. They may call `poll()` in their thread-mode code. There's a new example, `t4_idle.rs`, that demonstrates the feature.

The PR also demonstrates that the async logger may schedule log messages from an interrupt. See the updated `t4_dma.rs` example for details.